### PR TITLE
Move unread count in title

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -137,7 +137,7 @@ function GoreadCtrl($scope, $http, $timeout, $window) {
 
 	$scope.updateTitle = function() {
 		var ur = $scope.unread['all'] || 0;
-		document.title = (ur != 0 ? ' (' + ur + ')' : '') + 'go read';
+		document.title = (ur != 0 ? '(' + ur + ') ' : '') + 'go read';
 	};
 
 	$scope.setCurrent = function(i, noClose, isClick) {


### PR DESCRIPTION
Count being in the right of the title will hide the count with a large number of tabs up.  Moving the count left of the title gives precedence to the unread count.

Before:

```
go read (123)
```

After:

```
(123) go read
```
