### PR TITLE
schedule feed updates dynamically based on average update frequency

### DIFF
--- a/goapp/settings.go.dist
+++ b/goapp/settings.go.dist
@@ -3,6 +3,7 @@ package goapp
 import (
 	"appengine"
 	"code.google.com/p/goauth2/oauth"
+	"time"
 )
 
 var (
@@ -18,6 +19,16 @@ const (
 	GOOGLE_ANALYTICS_HOST = ""
 	PUBSUBHUBBUB_HUB = "http://pubsubhubbub.appspot.com"
 	PUBSUBHUBBUB_HOST = "" // e.g., "www.goread.io"
+)
+
+const (
+	UpdateMin         = time.Minute * 20
+	UpdateMax         = time.Hour * 12
+	UpdateDefault     = time.Hour * 3
+	UpdateFraction    = 0.5
+	UpdateJitter      = time.Minute * 3
+	UpdateLongFactor  = 20
+	NewIntervalWeight = 0.2
 )
 
 func init() {

--- a/goapp/tasks.go
+++ b/goapp/tasks.go
@@ -460,6 +460,7 @@ func updateFeed(c mpg.Context, url string, feed *Feed, stories []*Story) error {
 		feed.Updated = f.Updated
 	}
 	feed.Date = f.Date
+	feed.Average = f.Average
 	f = *feed
 
 	if hasUpdated && isFeedUpdated {
@@ -515,11 +516,16 @@ func updateFeed(c mpg.Context, url string, feed *Feed, stories []*Story) error {
 
 	c.Debugf("putting %v entities", len(puts))
 	if len(puts) > 1 {
+		updateAverage(&f, f.Date, len(puts)-1)
 		f.Date = time.Now()
 		if !hasUpdated {
 			f.Updated = f.Date
 		}
 	}
+	scheduleNextUpdate(&f)
+	delay := f.NextUpdate.Sub(time.Now())
+	c.Infof("next update scheduled for %v from now", delay-delay%time.Second)
+
 	gn.PutMulti(puts)
 
 	return nil

--- a/goapp/types.go
+++ b/goapp/types.go
@@ -51,17 +51,18 @@ type UserData struct {
 type Read map[string][]string
 
 type Feed struct {
-	_kind      string    `goon:"kind,F"`
-	Url        string    `datastore:"-" goon:"id"`
-	Title      string    `datastore:"t,noindex"`
-	Updated    time.Time `datastore:"u,noindex"`
-	Date       time.Time `datastore:"d,noindex"`
-	Checked    time.Time `datastore:"c,noindex"`
-	NextUpdate time.Time `datastore:"n"`
-	Link       string    `datastore:"l,noindex"`
-	Errors     int       `datastore:"e,noindex"`
-	Image      string    `datastore:"i,noindex"`
-	Subscribed time.Time `datastore:"s,noindex"`
+	_kind      string        `goon:"kind,F"`
+	Url        string        `datastore:"-" goon:"id"`
+	Title      string        `datastore:"t,noindex"`
+	Updated    time.Time     `datastore:"u,noindex"`
+	Date       time.Time     `datastore:"d,noindex"`
+	Checked    time.Time     `datastore:"c,noindex"`
+	NextUpdate time.Time     `datastore:"n"`
+	Link       string        `datastore:"l,noindex"`
+	Errors     int           `datastore:"e,noindex"`
+	Image      string        `datastore:"i,noindex"`
+	Subscribed time.Time     `datastore:"s,noindex"`
+	Average    time.Duration `datastore:"a,noindex"`
 }
 
 func (f Feed) Subscribe(c appengine.Context) {

--- a/goapp/utils.go
+++ b/goapp/utils.go
@@ -425,12 +425,9 @@ func findBestAtomLink(c appengine.Context, links []atom.Link) atom.Link {
 	return bestlink
 }
 
-const UpdateTime = time.Hour * 3
-
 func parseFix(c appengine.Context, f *Feed, ss []*Story) (*Feed, []*Story) {
 	g := goon.FromContext(c)
 	f.Checked = time.Now()
-	f.NextUpdate = f.Checked.Add(UpdateTime - time.Second*time.Duration(rand.Int63n(60*30)))
 	fk := g.Key(f)
 	f.Image = loadImage(c, f)
 
@@ -544,4 +541,61 @@ func loadImage(c appengine.Context, f *Feed) string {
 	i.Url = su.String()
 	g.Put(i)
 	return i.Url
+}
+
+func updateAverage(f *Feed, previousUpdate time.Time, updateCount int) {
+	if previousUpdate.IsZero() || updateCount < 1 {
+		return
+	}
+
+	// if multiple updates occurred, assume they were evenly spaced
+	interval := time.Since(previousUpdate) / time.Duration(updateCount)
+
+	// rather than calculate a strict mean, we weight
+	// each new interval, gradually decaying the influence
+	// of older intervals
+	old := float64(f.Average) * (1.0 - NewIntervalWeight)
+	cur := float64(interval) * NewIntervalWeight
+	f.Average = time.Duration(old + cur)
+}
+
+func scheduleNextUpdate(f *Feed) {
+	now := time.Now()
+	if f.Date.IsZero() {
+		f.NextUpdate = now.Add(UpdateDefault)
+		return
+	}
+
+	// calculate the delay until next check based on average time between updates
+	pause := time.Duration(float64(f.Average) * UpdateFraction)
+
+	// if we have never found an update, start with a default wait time
+	if pause == 0 {
+		pause = UpdateDefault
+	}
+
+	// if it has been much longer than expected since the last update,
+	// gradually reduce the frequency of checks
+	since := time.Since(f.Date)
+	if since > pause*UpdateLongFactor {
+		pause = time.Duration(float64(since) / UpdateLongFactor)
+	}
+
+	// enforce some limits
+	if pause < UpdateMin {
+		pause = UpdateMin
+	}
+	if pause > UpdateMax {
+		pause = UpdateMax
+	}
+
+	// introduce a little random jitter to break up
+	// convoys of updates
+	jitter := time.Duration(rand.Int63n(int64(UpdateJitter)))
+	if rand.Intn(2) == 0 {
+		pause += jitter
+	} else {
+		pause -= jitter
+	}
+	f.NextUpdate = time.Now().Add(pause)
 }


### PR DESCRIPTION
Rather than checking each feed on a fixed schedule, this patch varies the frequency of checks based on the history of that feed. There are a few parts:
1. Add an Average field to Feed. This tracks the average interval that we have observed between updates for the feed.
2. Update the Average field whenever new stories are found. The old average is merged with the new interval in such a way that the importance of older intervals gradually decays, so new data points are more important than older ones. This is computed based on the observed delay, not the time stamps in the feeds and stories themselves, since they are so unreliable. Precision doesn't matter here anyway, a rough estimate is good enough.
3. Schedule the next check for a feed by waiting some fraction of the average update interval for that feed. This is bounded on the high and low end to ensure sanity. Also, after a while with no updates, the interval is gradually increased.

The process is controlled by a series of const values in settings.go:
- UpdateMin (20 minutes): the minimum time between checks
- UpdateMax (12 hours): the maximum time between checks
- UpdateDefault (3 hours): the default time, mostly for new feeds
- UpdateFraction (0.5): if a feed has a new story on average every N minutes, check for new stories every N &times; UpdateFraction minutes. 0.5 means we expect to check each source about twice for each update. Setting it too close to 1 risks just missing updates on sites with scheduled updates (think daily comics) and then waiting a long time before checking again
- UpdateJitter (3 minutes): randomly vary the wait time +/- this much
- UpdateLongFactor (20): if a feed has not been updated in 20 times the normal interval, gradually start slowing down the frequency of checks
- NewIntervalWeight (0.2): a new data point for how frequently a feed is updated is given 20% weight in the overall average, and old values are compressed down to account for the other 80%.

Note: this makes changes to settings.go.dist, so the corresponding settings.go must be updated as well.
