### PR TITLE
Make story-title less prominent after read

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -50,6 +50,9 @@
 			text-overflow: ellipsis;
 			white-space: nowrap;
 		}
+		.story-header.read .story-title {
+			color: #777;
+		}
 		.feed-title, .folder-title {
 			padding: 2px;
 		}


### PR DESCRIPTION
right now the title keeps being black after read an entry

Before: http://cl.ly/image/1q1E0K370S3I

After: http://cl.ly/image/2J3Z0m1H0m2S
