### PR TITLE
Suppress passthrough of keyboard shortcuts

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -648,25 +648,31 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 	var shortcuts = $('#shortcuts');
 	Mousetrap.bind('?', function() {
 		shortcuts.modal('toggle');
+		return false;
 	});
 	Mousetrap.bind('esc', function() {
 		shortcuts.modal('hide');
+		return false;
 	});
 	Mousetrap.bind('r', function() {
 		if ($scope.nouser) {
 			return;
 		}
 		$scope.$apply($scope.refresh());
+		return false;
 	});
 	Mousetrap.bind(['j', 'n', 'space'], function() {
 		$scope.$apply('next()');
+		return false;
 	});
 	Mousetrap.bind(['k', 'p', 'shift+space'], function() {
 		$scope.$apply('prev()');
+		return false;
 	});
 	Mousetrap.bind('v', function() {
 		if ($scope.dispStories[$scope.currentStory]) {
 			window.open($scope.dispStories[$scope.currentStory].Link);
+			return false;
 		}
 	});
 	Mousetrap.bind('shift+a', function() {
@@ -674,27 +680,33 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 			return;
 		}
 		$scope.$apply($scope.markAllRead());
+		return false;
 	});
 	Mousetrap.bind('a', function() {
 		if ($scope.nouser) {
 			return;
 		}
 		$scope.$apply("setAddSubscription()");
+		return false;
 	});
 	Mousetrap.bind('g a', function() {
 		if ($scope.nouser) {
 			return;
 		}
 		$scope.$apply("shown = 'feeds'; setActiveFeed();");
+		return false;
 	});
 	Mousetrap.bind('u', function() {
 		$scope.$apply("toggleNav()");
+		return false;
 	});
 	Mousetrap.bind('1', function() {
 		$scope.$apply("setExpanded(true)");
+		return false;
 	});
 	Mousetrap.bind('2', function() {
 		$scope.$apply("setExpanded(false)");
+		return false;
 	});
 
 	$scope.showMessage = function(m) {


### PR DESCRIPTION
When pressing any of the designated keyboard shortcuts, the keypress event
was being passed onto the browser afterward instead of being ended by the
page. This causes problems with things such as the "search when typing" option
with firefox, etc.
