### PR TITLE
Improve heuristics for selecting a link URL.

### DIFF
--- a/goapp/atom/atom.go
+++ b/goapp/atom/atom.go
@@ -1,0 +1,59 @@
+// Copyright 2009 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Adapted from encoding/xml/read_test.go.
+
+// Package atom defines XML data structures for an Atom feed.
+package atom
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+type Feed struct {
+	XMLName xml.Name    `xml:"http://www.w3.org/2005/Atom feed"`
+	Title   string  `xml:"title"`
+	ID      string  `xml:"id"`
+	Link    []Link  `xml:"link"`
+	Updated TimeStr    `xml:"updated"`
+	Author  *Person  `xml:"author"`
+	Entry   []*Entry `xml:"entry"`
+}
+
+type Entry struct {
+	Title   string `xml:"title"`
+	ID      string `xml:"id"`
+	Link    []Link `xml:"link"`
+	Published TimeStr `xml:"published"`
+	Updated TimeStr   `xml:"updated"`
+	Author  *Person `xml:"author"`
+	Summary *Text   `xml:"summary"`
+	Content *Text `xml:"content"`
+}
+
+type Link struct {
+	Rel  string `xml:"rel,attr"`
+	Href string `xml:"href,attr"`
+	Type string `xml:"type,attr"`
+}
+
+type Person struct {
+	Name     string `xml:"name"`
+	URI      string `xml:"uri"`
+	Email    string `xml:"email"`
+	InnerXML string `xml:",innerxml"`
+}
+
+type Text struct {
+	Type string `xml:"type,attr"`
+	Body string `xml:",chardata"`
+}
+
+type TimeStr string
+
+func Time(t time.Time) TimeStr {
+	return TimeStr(t.Format("2006-01-02T15:04:05-07:00"))
+}
+

--- a/goapp/utils.go
+++ b/goapp/utils.go
@@ -17,6 +17,7 @@
 package goapp
 
 import (
+	"goapp/atom"
 	"bytes"
 	"encoding/xml"
 	"errors"
@@ -41,7 +42,6 @@ import (
 	"appengine/user"
 	"code.google.com/p/go-charset/charset"
 	_ "code.google.com/p/go-charset/data"
-	"code.google.com/p/rsc/blog/atom"
 	mpg "github.com/MiniProfiler/go/miniprofiler_gae"
 	"github.com/mjibson/goon"
 	"github.com/mjibson/rssgo"
@@ -290,11 +290,9 @@ func ParseFeed(c appengine.Context, u string, b []byte) (*Feed, []*Story) {
 		if t, err := parseDate(c, &f, string(a.Updated)); err == nil {
 			f.Updated = t
 		}
-		for _, l := range a.Link {
-			if l.Rel != "self" {
-				f.Link = l.Href
-				break
-			}
+
+		if len(a.Link) > 0 {
+			f.Link = findBestAtomLink(c, a.Link).Href
 		}
 
 		for _, i := range a.Entry {
@@ -309,7 +307,7 @@ func ParseFeed(c appengine.Context, u string, b []byte) (*Feed, []*Story) {
 				st.Published = t
 			}
 			if len(i.Link) > 0 {
-				st.Link = i.Link[0].Href
+				st.Link = findBestAtomLink(c, i.Link).Href
 			}
 			if i.Author != nil {
 				st.Author = i.Author.Name
@@ -401,6 +399,28 @@ func ParseFeed(c appengine.Context, u string, b []byte) (*Feed, []*Story) {
 	c.Warningf("xml parse error: %s", rsserr.Error())
 	c.Warningf("rdf parse error: %s", rdferr.Error())
 	return nil, nil
+}
+
+func findBestAtomLink(c appengine.Context, links []atom.Link) atom.Link {
+	getScore := func (l atom.Link) int {
+		switch {
+		case l.Type == "text/html": return 3
+		case l.Rel != "self": return 2
+		default: return 1
+		}
+	}
+
+	var bestlink atom.Link
+	bestscore := -1
+	for _, l := range links {
+		score := getScore(l)
+		if score > bestscore {
+			bestlink = l
+			bestscore = score
+		}
+	}
+
+	return bestlink
 }
 
 const UpdateTime = time.Hour * 3


### PR DESCRIPTION
Many atom feeds have multiple `link` elements, some of which point to resources other than web pages.  This patch tries to find the best feed based on the `type` attribute.

Example of feed that is currently broken: http://googlenewsblog.blogspot.com/feeds/posts/default

The atom package cannot access the type attribute of link elements, so I added a tweaked version at `goapp/atom`.

Sorry if the code is a bit rough -- I've never used Go before. :)
