### PR TITLE
Disable the import button when importing feed

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -55,16 +55,19 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 		});
 	};
 
-	$scope.addSubscription = function() {
+	$scope.addSubscription = function(e) {
 		if (!$scope.addFeedUrl) {
 			return false;
 		}
+		var btn = $(e.target);
+		btn.button('loading')
 		$scope.loading++;
 		var f = $('#add-subscription-form');
 		$scope.http('POST', f.attr('data-url'), {
 			url: $scope.addFeedUrl
 		}).then(function() {
 			$scope.addFeedUrl = '';
+			btn.button('reset')
 			// I think this is needed due to the datastore's eventual consistency.
 			// Without the delay we only get the feed data with no story data.
 			$timeout(function() {
@@ -75,6 +78,7 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 				alert(data.data);
 			}
 			$scope.loading--;
+			btn.button('reset')
 		});
 	};
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -487,7 +487,7 @@
 					<fieldset>
 						<legend>Feed URL</legend>
 						<input type="text" class="span12" ng-model="addFeedUrl">
-						<p><button ng-click="addSubscription()" class="btn">import</button></p>
+						<p><button ng-click="addSubscription($event)" data-loading-text="importing.." class="btn">import</button></p>
 					</fieldset>
 				</form>
 			</div>


### PR DESCRIPTION
Minor user interface tweak. With this patch, the feed import button will be disabled (and relabeled as "importing..") after it's clicked. It will be enabled again after the feed is imported or error occurs. I think disabling/relabeling the button will give impression/feed back that something is happening.
