### PR TITLE
Added a shortcut to open current story in a background tab

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -942,6 +942,15 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 			return false;
 		}
 	});
+    Mousetrap.bind('b', function() {
+        if ($scope.dispStories[$scope.currentStory]) {
+            var $link = $('div .story.selected .story-content a:first');
+            var evt = document.createEvent("MouseEvents");
+            evt.initMouseEvent("click", true, true, window, 0, 0, 0, 0, 0, true, false, false, true, 0, null);
+            $link[0].dispatchEvent(evt);
+            return false;
+        }
+    });
 	Mousetrap.bind('shift+a', function() {
 		if ($scope.nouser) {
 			return;


### PR DESCRIPTION
It is 'b' as suggested in issue #62. This only works in Chrome and Opera. Firefox does nothing at all, and IE opens the story in a new tab, but still switches focus to it.
