### PR TITLE
Show stories incrementally

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -178,6 +178,7 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 				if (typeof cb === 'function') cb();
 				$scope.loaded();
 				$scope.update();
+				$scope.resetLimit();
 				setTimeout($scope.applyGetFeed);
 			})
 			.error(function() {
@@ -476,6 +477,14 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 			});
 	};
 
+	$scope.dispLimit = 10;
+	$scope.resetLimit = function() {
+		var storyHeight = 30; // FIXME find out the height of the story rows
+		var len = parseInt($(window).height() / storyHeight);
+		if (len < 10) len = 10;
+		$scope.dispLimit = len;
+	}
+
 	$scope.setActiveFeed = function(feed) {
 		delete $scope.activeFolder;
 		$scope.activeFeed = feed;
@@ -484,6 +493,7 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 		$scope.applyGetFeed();
 		$scope.updateUnreadCurrent();
 		$scope.resetScroll();
+		$scope.resetLimit();
 	};
 
 	$scope.setActiveFolder = function(folder) {
@@ -751,7 +761,28 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 		$scope.$apply(function() {
 			$scope.collapsed = $(window).width() <= 979;
 		});
+		$scope.checkLoadNextPage();
 	}, 300);
+
+	$scope.checkLoadNextPage = function() {
+		var sh = sl[0].scrollHeight;
+		var h = Math.min(sl.height(), $(window).height());
+		var st = Math.max(sl.scrollTop(), $(window).scrollTop());
+		if (sh - (st + h) > 200) {
+			return;
+		}
+		$scope.loadNextPage();
+	};
+
+	$scope.loadNextPage = function() {
+		var max = $scope.dispStories.length;
+		var len = $scope.dispLimit + 10;
+		if (len > max) len = max;
+		$scope.$apply(function() {
+			$scope.dispLimit = len;
+		});
+	};
+
 	sl.on('scroll', $scope.onScroll);
 	$window.onscroll = $scope.onScroll;
 	$window.onresize = $scope.onScroll;

--- a/templates/base.html
+++ b/templates/base.html
@@ -544,7 +544,7 @@
 					</div>
 				</div>
 				<div
-					ng-repeat="s in dispStories"
+					ng-repeat="s in dispStories | limitTo:dispLimit"
 					class="story"
 					ng-mouseenter="overContents(s)"
 					ng-mouseleave="leaveContents(s)"


### PR DESCRIPTION
This is my attempt for "infinite scrolling". It works on both desktop and mobile versions (tested on iPad and Nexus 4). This also reduce the response time to render the page by showing the content progressively.

It still has one `FIXME` though. I need to know the height of a story row so I can show the correct amount of initial stories, which should correspond to the height of the browser window.
