### PR TITLE
Make the story list scrolling snappy on iPad

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -109,6 +109,7 @@
 			position: absolute;
 			left: 245px;
 			overflow-y: auto;
+			-webkit-overflow-scrolling: touch;
 			top: 40px;
 			bottom: 0;
 			right: 0;


### PR DESCRIPTION
Using (only) `overflow:scroll` apparently makes the scrolling sluggish. This will make it snappy again.

Possibly relevant reference: http://cantina.co/2012/03/06/ios-5-native-scrolling-grins-and-gothcas/

The following might need to be added, but I think let's see how it goes first (?)

```
#story-list > * {
  -webkit-transform: translate3d(0,0,0);
}
```

Reference: http://stackoverflow.com/a/11361719/252384
