### PR TITLE
Very lightweight bidi support by dir="auto", couldn't be done with CSS

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -564,12 +564,12 @@
 					</div>
 					<div ng-show="$index == currentStory || (opts.expanded && !collapsed)">
 						<div class="story-content" ng-click="setCurrent($index, true, true)" ng-class="{short: opts.nav}">
-							<h3><a ng-href="{{`{{s.Link}}`}}" target="_blank" ng-bind="s.Title"></a></h3>
+							<h3 dir="auto"><a ng-href="{{`{{s.Link}}`}}" target="_blank" ng-bind="s.Title"></a></h3>
 							<p><small>
 								from <a ng-href="{{`{{s.feed.HtmlUrl}}`}}" ng-bind="s.feed.Title" target="_blank"></a>
 								<span ng-show="s.Author">by {{`{{s.Author}}`}}</span>
 							</small></p>
-							<div ng-switch on="$index == currentStory || (opts.expanded && !collapsed)">
+							<div ng-switch on="$index == currentStory || (opts.expanded && !collapsed)" dir="auto">
 								<div ng-switch-when="true">
 									<div ng-bind-html-unsafe="contents[s.guid]" class="clearfix"></div>
 									<div ng-show="s.MediaContent" ng-switch on="s.MediaContent != undefined">


### PR DESCRIPTION
I just tested it from browser inspector. It's idea is very simple:
Before:
![2013-07-19 13_48_10-go read](https://f.cloud.github.com/assets/833473/824857/472230a6-f054-11e2-874c-6a5c1e7e807b.png)
After:
![2013-07-19 13_48_53-go read](https://f.cloud.github.com/assets/833473/824859/502c067c-f054-11e2-97ca-64bcc7aa284d.png)
By this simple solution goread will support RTL (Persian/Arabic, Hebrew, ...) languages.
Alternative solution can be done like this https://github.com/Athou/commafeed/commit/9568ccfeacc411b8565bee8bc26b2296825fdb4a but https://code.google.com/p/google-web-toolkit/source/browse/trunk/user/src/com/google/gwt/i18n/shared/BidiUtils.java must ported for it so I think for now, this would be enough
