### PR TITLE
Add Google+ sharing for stories

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -219,6 +219,7 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 				if (!isClick || eTop < 0 || eTop > $('#story-list').height() || (isClick && !middleClick && !noOpen && $scope.opts.expanded)) {
 					se[0].scrollIntoView();
 				}
+				gapi.plus.go("storydiv" + i); // render G+ share
 			});
 		}
 		if (!middleClick && !noOpen) {
@@ -1095,3 +1096,15 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 		$scope.http('POST', $('#mark-all-read').attr('data-url'), { last: d.valueOf() });
 	};
 });
+
+window.___gcfg = {
+	lang: 'en-US',
+	parsetags: 'explicit'
+};
+
+(function() {
+	var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
+	po.src = 'https://apis.google.com/js/plusone.js';
+	var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
+})();
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -200,6 +200,9 @@
 				line-height: 43px;
 			}
 		}
+		li.g-plus div:first-child {
+			vertical-align: middle !important;
+		}
 	</style>
 	<link rel="shortcut icon" href="/static/favicon.png">
 </head>
@@ -607,6 +610,9 @@
 									<a target="_blank" ng-href="http://www.instapaper.com/hello2?url={{`{{s.Link | encodeURI}}`}}&title={{`{{s.Title | encodeURI}}`}}">
 										save to Instapaper
 									</a>
+								</li>
+								<li class="g-plus">
+									<div class="g-plus" data-annotation="none" data-height="15" data-action="share" ng-href="{{`{{s.Link}}`}}"></div>
 								</li>
 								<li ng-show="s.canUnread">
 									<form class="form-inline">


### PR DESCRIPTION
Uses the official G+ API to render the share icon. Chose annotation
"none" to keep things as clean as possible. Renders the icon
asynchronously, only when an item is displayed the first time, to keep
things light and fast for readers falling behind on their articles.

Signed-off-by: Dan Scott dan@coffeecode.net
