### PR TITLE
Add note about dev_appserver storing data in /tmp/ to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ a google reader clone built with go on app engine and angularjs
 1. `git checkout master` (bug in `go get`).
 1. Copy `app.sample.yaml` to `app.yaml`.
 1. In the `goapp` folder, copy `settings.go.dist` to `settings.go`.
-1. From the `goread` directory, start the app with `dev_appserver.py app.yaml`.
+1. From the `goread` directory, start the app with `dev_appserver.py app.yaml`. (Pass `--storage_dir /some/where` if you want your data to survive restarts. By default, your data will end up in `/tmp/`.)
 1. View at [localhost:8080](http://localhost:8080), admin console at [localhost:8000](http://localhost:8000).
  
 ## developer notes


### PR DESCRIPTION
I'm running goread locally using the dev appserver, was surprised to find that, if you don't pass `--storage_dir` when starting the server, you'll lose your data on every restart. Might be a good idea to add a note to the README.
