### PR TITLE
escape key also hide messages

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -999,6 +999,7 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 	});
 	Mousetrap.bind('esc', function() {
 		$scope.shortcuts.modal('hide');
+		$('#messages').modal('hide');
 		return false;
 	});
 	Mousetrap.bind('r', function() {


### PR DESCRIPTION
I wanted to dismiss the import message with a shortcut too. I haven't done much with `bootstrap.js` so there may be a better way, but this seems to work.
