### PR TITLE
#305 Many favicons are only available via HTTP, so leave the URL alone.

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -145,11 +145,6 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 				$scope.untilDays = data.UntilDate ? moment.unix(data.UntilDate).diff(moment(), 'days') : 0;
 				$scope.opml = data.Opml || $scope.opml || [];
 				_.each(data.Feeds, function(e) {
-					if(e.Image) {
-						if (e.Image.slice(0, 5) === "http:") {
-							e.Image = e.Image.slice(5);
-						}
-					}
 					e.Checked = moment(e.Checked).fromNow();
 					e.NextUpdate = moment(e.NextUpdate).fromNow();
 					$scope.feeds[e.Url] = e;


### PR DESCRIPTION
Test case: http://www.sheldoncomics.com/index.xml
Actual favicon http://www.sheldoncomics.com/favicon.ico
Requests to https://www.sheldoncomics.com/favicon.ico time out.
