### PR TITLE
Add .editorconfig file, to help maintain consistent formatting.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length=76
+
+[*.go]
+
+[*.js]
+
+# end


### PR DESCRIPTION
http://editorconfig.org/ allows different text editors
to use the same formatting conventions: space vs tabs, etc.
