### PR TITLE
#313 show message when user submits bad OPML

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -36,15 +36,18 @@ goReadAppModule.controller('GoreadCtrl', function($scope, $http, $timeout, $wind
 		$scope.shown = 'feeds';
 		$scope.loading++;
 		$('#import-opml-form').ajaxForm({
-			"clearForm": true,
-			"error": function(jqXHR, textStatus, errorThrown) {
-				$scope.showMessage(jqXHR.responseText); },
-			"success": function() {
+			clearForm: true,
+			error: function(jqXHR, textStatus, errorThrown) {
+				$scope.showMessage(jqXHR.responseText);
+			},
+			success: function() {
 				$scope.loaded();
 				$scope.showMessage("OPML import is happening."
 					+ " It can take a minute. Don't reorganize your feeds"
 					+ " until it's completed importing."
-					+ " Refresh to see its progress."); } });
+					+ " Refresh to see its progress.");
+			}
+		});
 	};
 
 	$scope.loaded = function() {

--- a/tasks.go
+++ b/tasks.go
@@ -53,8 +53,11 @@ func ImportOpmlTask(c mpg.Context, w http.ResponseWriter, r *http.Request) {
 	c.Debugf("reader import for %v, skip %v", userid, skip)
 
 	opml := Opml{}
-	gob.NewDecoder(
-		blobstore.NewReader(c, appengine.BlobKey(bk))).Decode(&opml)
+	dec := gob.NewDecoder(blobstore.NewReader(c, appengine.BlobKey(bk)))
+	err := dec.Decode(&opml)
+	if err != nil {
+		c.Warningf("gob decode failed: %v", err.Error())
+	}
 
 	remaining := skip
 	var userOpml []*OpmlOutline

--- a/user.go
+++ b/user.go
@@ -121,7 +121,12 @@ func ImportOpml(c mpg.Context, w http.ResponseWriter, r *http.Request) {
 			}
 
 			var b bytes.Buffer
-			gob.NewEncoder(&b).Encode(&opml)
+			enc := gob.NewEncoder(&b)
+			err := enc.Encode(&opml)
+			if err != nil {
+				serveError(w, err)
+				return
+			}
 			bk, err := saveFile(c, b.Bytes())
 			if err != nil {
 				serveError(w, err)


### PR DESCRIPTION
This moves the initial XML parsing into the form submit request,
then stores the resulting Opml object as a gob
instead of storing the raw upload bytes.
If the upload is malformed, the request response body
includes a copy of the full error message.
The ajaxform code will show this to the user as a new message.

There may be some risk in moving work into the main request,
because appengine likes requests to be low-latency.
I think it's a reasonable tradeoff, in part because
imports are relatively infrequest.
